### PR TITLE
Set policies for self approve and tagger

### DIFF
--- a/.miniprow.yaml
+++ b/.miniprow.yaml
@@ -16,18 +16,45 @@ approve:
   auto_apply: true
 
 override:
-  allow: [puerco]  # users who may /override 
+  allow: [puerco]  # users who may /override
+
+policy:
+  # Self-action gate. Before miniprow lets a PR author self-approve (/approve or
+  # approve.auto_apply) or self-lgtm (/lgtm or lgtm.auto_apply) their own pull
+  # request, every policy under `self` must pass against the PR head commit. A
+  # genuine second-party /approve or /lgtm always bypasses these policies, and
+  # any evaluation error, missing evidence, or FAIL fails closed.
+  #
+  # Here we require the head commit to carry a valid gitsign signature from
+  # puerco — the same policy the tagger enforces below — so an author can only
+  # self-authorise a commit they signed. The collector init string is templated
+  # just-in-time with the ${MINIPROW_*} variables and, via the `gitsign:`
+  # moniker, miniprow injects the installation token and the PR's
+  # refs/pull/N/head reference.
+  self:
+    - id: gitsign-commit-signature
+      location:
+        uri: git+https://github.com/carabiner-dev/policies#gitsign/gitsign-commit-signature.hjson
+      identities:
+        - "sigstore::https://accounts.google.com::puerco@carabiner.dev"
+      collectors:
+        - "gitsign:https://github.com/${MINIPROW_BASE_ORG}/${MINIPROW_BASE_REPO}@${MINIPROW_PR_HEAD_COMMIT}"
 
 tagger:
   enabled: true
   policies:
     # `all` is evaluated for every bump. The gitsign-commit-signature policy
-    # verifies the head commit's gitsign signature; the gitsign evidence
-    # collector is injected automatically by miniprow (scoped to the PR's
-    # refs/pull/N/head), so no `evidence:` entry is needed here.
+    # verifies the head commit's gitsign signature. Its collector init string is
+    # templated just-in-time with the ${MINIPROW_*} variables (here the base
+    # org/repo and the PR head commit), and because the init string uses the
+    # `gitsign:` moniker miniprow injects the authenticated collector's runtime
+    # options — the installation token and the PR's refs/pull/N/head — so no
+    # other configuration is needed.
     all:
       - id: gitsign-commit-signature
         location:
           uri: git+https://github.com/carabiner-dev/policies#gitsign/gitsign-commit-signature.hjson
         identities:
           - "sigstore::https://accounts.google.com::puerco@carabiner.dev"
+        collectors:
+          - "gitsign:https://github.com/${MINIPROW_BASE_ORG}/${MINIPROW_BASE_REPO}@${MINIPROW_PR_HEAD_COMMIT}"


### PR DESCRIPTION
This pull request updates the `.miniprow.yaml` configuration to strengthen commit signature verification policies for both approving and tagging pull requests. The main change is the introduction of a self-approval policy that requires PR authors to sign their commits with a verified gitsign signature before they can self-approve or self-lgtm their own PRs. Additionally, the tagger policy is clarified and updated to explicitly specify the gitsign collector.

**Policy enforcement improvements:**

* Added a new `self` policy under `approve:` that requires the PR author to have a valid gitsign signature for self-approval actions, ensuring only signed commits can be self-authorized.
* Updated the `tagger` policy to explicitly specify the gitsign collector and clarified the templating and injection of runtime options for signature verification.